### PR TITLE
chord-joint-extract.py add alternative writing

### DIFF
--- a/chord-joint-extract.py
+++ b/chord-joint-extract.py
@@ -36,6 +36,13 @@ for line in file:
 file.close()
 
 # Print list joint into files
-with open ("ChordNodes.csv", "w") as output:
-    writer = csv.writer(output, lineterminator='\n')
-    writer.writerows(result)
+###with open ("ChordNodes.csv", "w") as output:
+###    writer = csv.writer(output, lineterminator='\n')
+###    writer.writerows(result)
+
+# Print list joint into files using standard python
+with open('ChordNodes.txt', "w") as output:
+    output.write("Joint        Chord1      Chord2\n")
+    for i, item in enumerate(result):
+        output.write(str(item[0])+"    "+str(item[1])+"    "+str(item[2]) + "\n")
+


### PR DESCRIPTION
add alternative way in writing the list into text file. With column headers
I think it is better to use the CSV with header
